### PR TITLE
Add legacy include path support to silverorange/botr_api package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,8 @@
 		"psr-0": {
 			"BotrAPI" : ""
 		}
-	}
+	},
+	"include-path": [
+		"./"
+	]
 }


### PR DESCRIPTION
https://trello.com/c/FTCnqtl4/1175-botrapi-package-doesn-t-support-legacy-include-path
